### PR TITLE
Added java model for base case

### DIFF
--- a/src/main/java/com/netflix/model/java/JavaModel.java
+++ b/src/main/java/com/netflix/model/java/JavaModel.java
@@ -1,0 +1,147 @@
+package com.netflix.model.java;
+
+import java.util.List;
+
+public class JavaModel {
+    private Integer integer;
+    private List<String> list;
+    private String str1;
+    private String str2;
+    private String str3;
+    private String str4;
+    private String str5;
+    private String str6;
+    private Double doub;
+
+    public JavaModel(Integer integer, List<String> list, String str1, String str2, String str3, String str4, String str5, String str6, Double doub) {
+        this.integer = integer;
+        this.list = list;
+        this.str1 = str1;
+        this.str2 = str2;
+        this.str3 = str3;
+        this.str4 = str4;
+        this.str5 = str5;
+        this.str6 = str6;
+        this.doub = doub;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+
+    public void setInteger(Integer integer) {
+        this.integer = integer;
+    }
+
+    public List<String> getList() {
+        return list;
+    }
+
+    public void setList(List<String> list) {
+        this.list = list;
+    }
+
+    public String getStr1() {
+        return str1;
+    }
+
+    public void setStr1(String str1) {
+        this.str1 = str1;
+    }
+
+    public String getStr2() {
+        return str2;
+    }
+
+    public void setStr2(String str2) {
+        this.str2 = str2;
+    }
+
+    public String getStr3() {
+        return str3;
+    }
+
+    public void setStr3(String str3) {
+        this.str3 = str3;
+    }
+
+    public String getStr4() {
+        return str4;
+    }
+
+    public void setStr4(String str4) {
+        this.str4 = str4;
+    }
+
+    public String getStr5() {
+        return str5;
+    }
+
+    public void setStr5(String str5) {
+        this.str5 = str5;
+    }
+
+    public String getStr6() {
+        return str6;
+    }
+
+    public void setStr6(String str6) {
+        this.str6 = str6;
+    }
+
+    public Double getDoub() {
+        return doub;
+    }
+
+    public void setDoub(Double doub) {
+        this.doub = doub;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        JavaModel javaModel = (JavaModel) o;
+
+        if (integer != null ? !integer.equals(javaModel.integer) : javaModel.integer != null) return false;
+        if (list != null ? !list.equals(javaModel.list) : javaModel.list != null) return false;
+        if (str1 != null ? !str1.equals(javaModel.str1) : javaModel.str1 != null) return false;
+        if (str2 != null ? !str2.equals(javaModel.str2) : javaModel.str2 != null) return false;
+        if (str3 != null ? !str3.equals(javaModel.str3) : javaModel.str3 != null) return false;
+        if (str4 != null ? !str4.equals(javaModel.str4) : javaModel.str4 != null) return false;
+        if (str5 != null ? !str5.equals(javaModel.str5) : javaModel.str5 != null) return false;
+        if (str6 != null ? !str6.equals(javaModel.str6) : javaModel.str6 != null) return false;
+        return !(doub != null ? !doub.equals(javaModel.doub) : javaModel.doub != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = integer != null ? integer.hashCode() : 0;
+        result = 31 * result + (list != null ? list.hashCode() : 0);
+        result = 31 * result + (str1 != null ? str1.hashCode() : 0);
+        result = 31 * result + (str2 != null ? str2.hashCode() : 0);
+        result = 31 * result + (str3 != null ? str3.hashCode() : 0);
+        result = 31 * result + (str4 != null ? str4.hashCode() : 0);
+        result = 31 * result + (str5 != null ? str5.hashCode() : 0);
+        result = 31 * result + (str6 != null ? str6.hashCode() : 0);
+        result = 31 * result + (doub != null ? doub.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "JavaModel{" +
+                "integer=" + integer +
+                ", list=" + list +
+                ", str1='" + str1 + '\'' +
+                ", str2='" + str2 + '\'' +
+                ", str3='" + str3 + '\'' +
+                ", str4='" + str4 + '\'' +
+                ", str5='" + str5 + '\'' +
+                ", str6='" + str6 + '\'' +
+                ", doub=" + doub +
+                '}';
+    }
+}

--- a/src/test/java/com/netflix/model/EqualsBenchmark.java
+++ b/src/test/java/com/netflix/model/EqualsBenchmark.java
@@ -10,6 +10,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class EqualsBenchmark {
+    @Benchmark public boolean equalsJava(JavaState state) {
+        return state.m.equals(state.m2);
+    }
     @Benchmark public boolean equalsGroovy(GroovyState state) {
         return state.m.equals(state.m2);
     }

--- a/src/test/java/com/netflix/model/HashCodeBenchmark.java
+++ b/src/test/java/com/netflix/model/HashCodeBenchmark.java
@@ -10,8 +10,10 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class HashCodeBenchmark {
-    @Benchmark
-    public int hashCodeGroovy(GroovyState state) {
+    @Benchmark public int hashCodeJava(JavaState state) {
+        return state.m.hashCode() + state.m2.hashCode();
+    }
+    @Benchmark public int hashCodeGroovy(GroovyState state) {
         return state.m.hashCode() + state.m2.hashCode();
     }
     @Benchmark public int hashCodeLombok(LombokState state) {

--- a/src/test/java/com/netflix/model/JavaState.java
+++ b/src/test/java/com/netflix/model/JavaState.java
@@ -1,0 +1,21 @@
+package com.netflix.model;
+
+import com.netflix.model.java.JavaModel;
+import com.netflix.model.lombok.LombokModel;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.util.Arrays;
+
+@State(Scope.Benchmark)
+public class JavaState {
+    JavaModel m;
+    JavaModel m2;
+
+    @Setup
+    public void prepare() {
+        m =  new JavaModel(1, Arrays.asList("1", "2", "3", "4", "5"), "1","2","3","4","5","6", 1.0);
+        m2 = new JavaModel(1, Arrays.asList("1","2","3","4","5"), "1","2","3","4","5","6", 1.5);
+    }
+}

--- a/src/test/java/com/netflix/model/ToStringBenchmark.java
+++ b/src/test/java/com/netflix/model/ToStringBenchmark.java
@@ -10,8 +10,10 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class ToStringBenchmark {
-    @Benchmark
-    public String toStringGroovy(GroovyState state) {
+    @Benchmark public String toStringJava(JavaState state) {
+        return state.m.toString();
+    }
+    @Benchmark public String toStringGroovy(GroovyState state) {
         return state.m.toString();
     }
     @Benchmark public String toStringLombok(LombokState state) {


### PR DESCRIPTION
Added generated java model as a base case to compare benchmarks against.

Running Oracle Java 8u31, I had the following results.
## equals()

```
Benchmark                         Mode  Cnt     Score    Error  Units
EqualsBenchmark.equalsGroovy      avgt   50    49.559 ±  0.076  ns/op
EqualsBenchmark.equalsJava        avgt   50    25.158 ±  0.021  ns/op
EqualsBenchmark.equalsKotlin      avgt   50    65.349 ±  1.478  ns/op
EqualsBenchmark.equalsLombok      avgt   50    24.225 ±  0.033  ns/op
EqualsBenchmark.equalsScala       avgt   50    49.021 ±  0.057  ns/op
```
## hashCode()

```
Benchmark                         Mode  Cnt     Score    Error  Units
HashCodeBenchmark.hashCodeGroovy  avgt   50  1128.820 ±  1.867  ns/op
HashCodeBenchmark.hashCodeJava    avgt   50    38.860 ±  0.077  ns/op
HashCodeBenchmark.hashCodeKotlin  avgt   50    38.549 ±  0.045  ns/op
HashCodeBenchmark.hashCodeLombok  avgt   50    47.462 ±  0.068  ns/op
HashCodeBenchmark.hashCodeScala   avgt   50   111.027 ±  0.199  ns/op
```
## toString()

```
Benchmark                         Mode  Cnt     Score    Error  Units
ToStringBenchmark.toStringGroovy  avgt   50  2301.196 ± 16.636  ns/op
ToStringBenchmark.toStringJava    avgt   50   409.006 ±  3.639  ns/op
ToStringBenchmark.toStringKotlin  avgt   50   376.617 ±  0.651  ns/op
ToStringBenchmark.toStringLombok  avgt   50   394.158 ±  2.804  ns/op
ToStringBenchmark.toStringScala   avgt   50   645.060 ±  1.102  ns/op
```
