### PR TITLE
Use the same types on Kotlin models as other models

### DIFF
--- a/src/main/kotlin/com/netflix/model/kotlin/KotlinLazyModel.kt
+++ b/src/main/kotlin/com/netflix/model/kotlin/KotlinLazyModel.kt
@@ -3,9 +3,9 @@ package com.netflix.model.kotlin
 import java.util.Objects
 import kotlin.properties.Delegates
 
-data class KotlinLazyModel(val myInt: Int, val myList: List<String>, val str1: String,
+data class KotlinLazyModel(val myInt: Int?, val myList: List<String>, val str1: String,
                            val str2: String, val str3: String, val str4: String,
-                           val str5: String, val str6: String, val doub: Double) {
+                           val str5: String, val str6: String, val doub: Double?) {
     val hash by Delegates.lazy { Objects.hash(myInt, myList, str1, str2, str3, str4, str5, str6) }
 
     override fun hashCode(): Int {

--- a/src/main/kotlin/com/netflix/model/kotlin/KotlinModel.kt
+++ b/src/main/kotlin/com/netflix/model/kotlin/KotlinModel.kt
@@ -1,5 +1,5 @@
 package com.netflix.model.kotlin
 
-data class KotlinModel(val myInt: Int, val myList: List<String>, val str1: String,
+data class KotlinModel(val myInt: Int?, val myList: List<String>, val str1: String,
                        val str2: String, val str3: String, val str4: String,
-                       val str5: String, val str6: String, val doub: Double)
+                       val str5: String, val str6: String, val doub: Double?)


### PR DESCRIPTION
The Kotlin models were declared with primitive types where all other models
were declared with boxed types. The Kotlin models now also have the boxed
types.
